### PR TITLE
Allow setting custom css classNames from options

### DIFF
--- a/src/confirm/index.tsx
+++ b/src/confirm/index.tsx
@@ -22,16 +22,39 @@ const ConfirmBox: React.FC<Props> = ({ resolver, message, options }: Props) => {
   };
 
   const render = () => {
+    const { classNames } = options || {};
+
+    const containerClassNames = `confirm - box__content $ {
+      classNames ?.container || ''
+    }
+    `;
+    const confirmButtonClassNames = `${classNames?.buttons || ''} $ {
+      classNames ?.confirmButton || ''
+    }
+    `;
+    const cancelButtonClassNames = `${classNames?.buttons || ''} $ {
+      classNames ?.cancelButton || ''
+    }
+    `;
+
     if (!options?.render) {
       return (
-        <div className="confirm-box__content">
+        <div className={containerClassNames}>
           <span>{message}</span>
           <div className="confirm-box__actions">
-            <button onClick={onConfirmPopup} role="confirmable-button">
+            <button
+              onClick={onConfirmPopup}
+              role="confirmable-button"
+              className={confirmButtonClassNames}
+            >
               {options?.labels?.confirmable ? options?.labels?.confirmable : 'Yes'}
             </button>
 
-            <button onClick={onCancelPopup} role="cancellable-button">
+            <button
+              onClick={onCancelPopup}
+              role="cancellable-button"
+              className={cancelButtonClassNames}
+            >
               {options?.labels?.cancellable ? options?.labels?.cancellable : 'No'}
             </button>
           </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
+type ClassNames = {
+  container?: string;
+  buttons?: string;
+  confirmButton?: string;
+  cancelButton?: string;
+};
+
 export type Options = {
-  labels?: {
-    confirmable: string;
-    cancellable: string;
-  };
+  labels?: { confirmable: string; cancellable: string };
+  classNames?: ClassNames;
   render?: (message: string, onConfirm: () => void, onCancel: () => void) => Element;
 };


### PR DESCRIPTION
# Feature: Implement custom class names
This PR extends the `options` to allow passing css class names to allow users to add custom styles

Example:
![image](https://user-images.githubusercontent.com/8494781/101495850-0dd37300-398f-11eb-8279-6307f7341bf9.png)
code:
![image](https://user-images.githubusercontent.com/8494781/101495368-82f27880-398e-11eb-854a-e9a07c80102e.png)

